### PR TITLE
Dockerizar el proyecto

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -1,0 +1,10 @@
+<VirtualHost *:80>
+	ServerName privatearea.lan
+	DocumentRoot "/var/www/html"
+
+	<Directory "/var/www/html">
+			Options Indexes FollowSymLinks
+			AllowOverride All
+			Require all granted
+	</Directory>
+</VirtualHost>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM mileschou/phalcon:5.6-apache
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git zip && \
+	apt-get install -y vim
+
+RUN curl -sS https://getcomposer.org/installer | \
+    php -- --install-dir=/usr/bin/ --filename=composer
+
+COPY . /var/www/html
+COPY ./000-default.conf /etc/apache2/sites-enabled/000-default.conf
+
+RUN a2enmod rewrite
+
+RUN composer install --no-dev --no-interaction -o 
+
+
+

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Execute test from folder tests.
 Review apache has permissions to write in privateArea/cache/volt folder.
 
 ## Dockerize  
-Execute:  
+### Execute:  
 	docker run --name test -p 8080:80 -d nikeyes/test-tech 
 	
-Create Image:  
-	docker image build -t test-tech .
-	docker image tag test-tech nikeyes/test-tech
-	docker image push nikeyes/test-tech
+### Create Image:  
+	docker image build -t test-tech .  
+	docker image tag test-tech nikeyes/test-tech  
+	docker image push nikeyes/test-tech  
 	

--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ Execute test from folder tests.
 - If message "Volt directory can't be written" is shown when access to website:
 
 Review apache has permissions to write in privateArea/cache/volt folder.
+
+## Dockerize  
+Execute:  
+	docker run --name test -p 8080:80 -d nikeyes/test-tech 
+	
+Create Image:  
+	docker image build -t test-tech .
+	docker image tag test-tech nikeyes/test-tech
+	docker image push nikeyes/test-tech
+	

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Review apache has permissions to write in privateArea/cache/volt folder.
 
 ## Dockerize  
 ### Execute:  
-	docker run --name test -p 8080:80 -d nikeyes/test-tech 
+	docker run --name test -p 8080:80 -d nikeyes/test-tech  
+	> Navigate To: http://localhost:8080
 	
 ### Create Image:  
 	docker image build -t test-tech .  


### PR DESCRIPTION
Hola Juan Carlos,

Soy Jorge de Habitaclia. Nos conocimos en la Gapand con Jesús.
Vamos a revisar tu prueba técnica pero como no usamos php no lo tenemos en nuestras máquinas.
Como soy un poco friki, y porque instalar el XAMPP era demasiado fácil, he dockerizado tu proyecto, así el que revise tu prueba técnica no tiene que instalarse nada. 
Solo bajar el repo para ver el código y para arrancar el proyecto, ejecutanado:
docker run --name test -p 8080:80 -d nikeyes/test-tech

Te dejo en el Readme los comandos que he usado y añado los ficheros necesarios para dockerizar el proyecto.

Cuando revisemos la prueba borrare la imagen de docker de DockerHub: https://hub.docker.com/r/nikeyes/test-tech/

Ya te contaremos como vemos la prueba!!

Un saludo,

Jorge
